### PR TITLE
 Retry failed Gerrit requests when auth tokens have timed out

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,7 @@
   config.ORIGIN_REGEXP = new RegExp('^' + config.ORIGIN_PATTERN);
 
   // Login prompt.
-  config.LOGIN_PROMPT = ' Try loggin in.';
+  config.LOGIN_PROMPT = ' Try logging in.';
 
   // Missing configuration.
   config.NO_HOST_ALLOWED = 'no host configured.';

--- a/src/gerrit.js
+++ b/src/gerrit.js
@@ -414,7 +414,7 @@
       .catch(function(error) {
         // Just pass through non-login errors.
         if (!(error instanceof browser.FetchError) || !error.is_login_error) {
-          return Promise.resolve(error);
+          return Promise.reject(error);
         }
         // Some Gerrit instances attempt to redirect the user via an
         // authentication server every few hours to refresh some cookies. Such
@@ -438,7 +438,7 @@
           })
           .catch(function(_) {
             // If we failed, return the original error we got.
-            return Promise.resolve(error);
+            return Promise.reject(error);
           });
       });
   };


### PR DESCRIPTION
Some Gerrit instances attempt to redirect the user via an authentication server every few hours to refresh some cookies. Such redirects will fail, due to Chrome's CORS restrictions.

In these cases, we can attempt to send an opaque request (with `mode: no-cors`) that _will_ successfully redirect via the authentication server and refresh any cookies, and then send the original request again.

This won't solve cases where a user needs to type in a password, but will allow GerritMonitor to continue working if the problem is simply an authentication cookie refresh was required.
