### PR TITLE
Fetch all required information from Gerrit for background refresh.

### DIFF
--- a/src/gerrit.js
+++ b/src/gerrit.js
@@ -263,8 +263,6 @@ export class Changelist {
   }
 
   // Returns the current revision (aka patchset) of this CL.
-  //
-  // Requires detailed information (see fetchReviews).
   getCurrentRevision() {
     if (this.current_revision_ === null) {
       this.current_revision_ = new Revision(
@@ -327,8 +325,6 @@ export class Revision {
   }
 
   // Returns index of this revision.
-  //
-  // Requires detailed information (see fetchReviews).
   getNumber() {
     return this.json_._number;
   }
@@ -547,14 +543,14 @@ export function fetchReviews(host, account, detailed) {
   var userid = account._account_id;
   params.push(['q', 'status:open owner:' + userid]);
   params.push(['q', 'status:open -star:ignore reviewer:' + userid + ' -owner:' + userid]);
+  params.push(['o', 'CURRENT_REVISION']);
   params.push(['o', 'DETAILED_LABELS']);
+  params.push(['o', 'MESSAGES']);
   params.push(['o', 'REVIEWED']);
   params.push(['o', 'SUBMITTABLE']);
-  params.push(['o', 'MESSAGES']);
   if (detailed) {
-    params.push(['o', 'DETAILED_ACCOUNTS']);
-    params.push(['o', 'CURRENT_REVISION']);
     params.push(['o', 'CURRENT_COMMIT']);
+    params.push(['o', 'DETAILED_ACCOUNTS']);
   }
   return sendRequest(host, '/changes/', params)
     .then(parseJSON)


### PR DESCRIPTION
Currently, background refreshes of data from Gerrit silently fail due to the error:

```
    TypeError: Cannot read property 'undefined' of undefined
        at Changelist.getCurrentRevision (gerrit.js:268)
        at Changelist.getCategory (gerrit.js:191)
        at gerrit.js:411
        at Array.forEach (<anonymous>)
        at SearchResult.getCategoryMap (gerrit.js:410)
        at gerrit.js:452
        at Array.forEach (<anonymous>)
        at SearchResults.getCategoryMap (gerrit.js:451)
        at update (badge.js:94)
        at badge.js:46
```

This is triggered because `getCurrentRevision` requires `CURRENT_REVISION` to be sent in the request to Gerrit, but the background badge refresh requests a non-detailed fetch of information, which doesn't include this.

This CL adds `CURRENT_REVISION` to the set of non-detailed information, resolving the above error.

I've kept the current detailed/non-detailed split, because requesting `DETAILED_ACCOUNTS` roughly triples the payload size in my (very brief) experiments.

Resolves sdefresne/gerrit-monitor#23