### PR TITLE
Implement basic notification support

### DIFF
--- a/src/background.html
+++ b/src/background.html
@@ -1,3 +1,4 @@
 <html>
   <script type="module" src="badge.js"></script>
+  <script type="module" src="notifications.js"></script>
 </html>

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,11 @@ export const NO_HOST_ALLOWED = 'No host configured.';
 // Delay between automatic refresh of the badge data.
 export const REFRESH_DELAY_IN_MINUTES = 5;
 
+// Notification options.
+export const NOTIFICATIONS_ENABLED = 'enabled';
+export const NOTIFICATIONS_DISABLED = 'disabled';
+export const NOTIFICATIONS_UNSPECIFIED = 'unspecified';
+
 // Default options.
 export const DEFAULT_OPTIONS = {
   // URL of the gerrit instance to monitor.
@@ -39,4 +44,12 @@ export const DEFAULT_OPTIONS = {
     host: 'https://fuchsia-review.googlesource.com',
     enabled: false,
   }],
+
+  // Should notifications been shown?
+  //
+  // The default is "unspecified", which currently means "no" but we may
+  // change to "yes" in the future. Having "unspecified" lets us distinguish
+  // between users who haven't made a choice versus those who have explictly
+  // opted out.
+  showNotifications: NOTIFICATIONS_UNSPECIFIED,
 };

--- a/src/gerrit.js
+++ b/src/gerrit.js
@@ -228,6 +228,11 @@ export class Changelist {
     return this.host_ + '/c/' + this.json_.project + '/+/' + this.json_._number;
   }
 
+  // Get the change ID.
+  getChangeId() {
+    return this.json_.id;
+  }
+
   // Returns the list of reviewers for this CL.
   getReviewers() {
     if (this.reviewers_ === null) {
@@ -269,6 +274,11 @@ export class Changelist {
           this.json_.revisions[this.json_.current_revision]);
     }
     return this.current_revision_;
+  }
+
+  // Gets the one-line subject of the CL.
+  getSubject() {
+    return this.json_.subject;
   }
 
   // Returns the CL description.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,8 @@
     "https://*/"
   ],
 
+  "options_page": "options.html",
+
   "browser_action": {
     "default_icon": {
       "24": "img/ic_assignment_black_24dp_1x.png",
@@ -28,11 +30,6 @@
     },
     "default_title": "Unknown",
     "default_popup": "popup.html"
-  },
-
-  "options_ui": {
-    "page": "options.html",
-    "chrome_style": true
   },
 
   "background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
   ],
 
   "optional_permissions": [
+    "notifications",
     "http://*/",
     "https://*/"
   ],

--- a/src/messages.js
+++ b/src/messages.js
@@ -73,11 +73,13 @@ BADGE_DATA[gerrit.Changelist.INCOMING_NEEDS_ATTENTION] = {
     '24': 'img/ic_assignment_incoming_24dp_1x.png',
     '48': 'img/ic_assignment_incoming_24dp_2x.png',
   },
+  shouldNotify: true,
   color: '#9a0007',
   formatTitle: function(count) {
     return count + ' incoming ' + pluralizedCl(count) +
         ' requiring your attention';
   },
+  notificationTitle: 'Incoming CL requiring your attention',
 };
 
 BADGE_DATA[gerrit.Changelist.OUTGOING_NEEDS_ATTENTION] = {
@@ -85,10 +87,12 @@ BADGE_DATA[gerrit.Changelist.OUTGOING_NEEDS_ATTENTION] = {
     '24': 'img/ic_assignment_outgoing_24dp_1x.png',
     '48': 'img/ic_assignment_outgoing_24dp_2x.png',
   },
+  shouldNotify: true,
   color: '#4d2c91',
   formatTitle: function(count) {
     return count + ' of your ' + pluralizedCl(count) + ' requiring your attention';
   },
+  notificationTitle: 'Outgoing CL requires attention',
 };
 
 BADGE_DATA[gerrit.Changelist.READY_TO_SUBMIT] = {
@@ -96,10 +100,12 @@ BADGE_DATA[gerrit.Changelist.READY_TO_SUBMIT] = {
     '24': 'img/ic_assignment_approved_24dp_1x.png',
     '48': 'img/ic_assignment_approved_24dp_2x.png',
   },
+  shouldNotify: true,
   color: '#004c40',
   formatTitle: function(count) {
     return count + ' of your ' + pluralizedCl(count) + ' ready to submit';
   },
+  notificationTitle: 'Approved CL is ready to submit',
 };
 
 BADGE_DATA[gerrit.Changelist.STALE] = {
@@ -107,10 +113,12 @@ BADGE_DATA[gerrit.Changelist.STALE] = {
     '24': 'img/ic_assignment_stale_24dp_1x.png',
     '48': 'img/ic_assignment_stale_24dp_2x.png',
   },
+  shouldNotify: false,
   color: '#004ba0',
   formatTitle: function(count) {
     return count + ' of your stale ' + pluralizedCl(count);
   },
+  notificationTitle: 'CL has become stale',
 };
 
 BADGE_DATA[gerrit.Changelist.NO_REVIEWERS] = {
@@ -118,10 +126,12 @@ BADGE_DATA[gerrit.Changelist.NO_REVIEWERS] = {
     '24': 'img/ic_assignment_not_ready_24dp_1x.png',
     '48': 'img/ic_assignment_not_ready_24dp_2x.png',
   },
+  shouldNotify: false,
   color: '#8d8d8d',
   formatTitle: function(count) {
     return count + ' of your ' + pluralizedCl(count) + ' not assigned reviewers';
   },
+  notificationTitle: 'CL has no reviewers set',
 };
 
 BADGE_DATA[gerrit.Changelist.WIP] = {
@@ -129,15 +139,18 @@ BADGE_DATA[gerrit.Changelist.WIP] = {
     '24': 'img/ic_assignment_not_ready_24dp_1x.png',
     '48': 'img/ic_assignment_not_ready_24dp_2x.png',
   },
+  shouldNotify: false,
   color: '#8d8d8d',
   formatTitle: function(count) {
     return count + ' of your work in progress ' + pluralizedCl(count);
   },
+  notificationTitle: 'CL marked as "work in progress"',
 };
 
 export const DEFAULT_BADGE_DATA = {
   text: '',
   title: NO_CLS_MESSAGE,
+  shouldNotify: false,
   icon: {
     '24': 'img/ic_assignment_black_24dp_1x.png',
     '48': 'img/ic_assignment_black_24dp_2x.png',
@@ -148,6 +161,7 @@ export const DEFAULT_BADGE_DATA = {
 export const LOADING_BADGE_DATA = {
   text: '...',
   title: 'Refreshing...',
+  shouldNotify: false,
   icon: {
     '24': 'img/ic_assignment_black_24dp_1x.png',
     '48': 'img/ic_assignment_black_24dp_2x.png',

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,128 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as browser from './browser.js';
+import * as config from './config.js';
+import * as messages from './messages.js';
+
+// Keys used for local storage to avoid duplicate notifications.
+const CL_LAST_NOTIFICATION_KEY = 'cl_last_notified';  // Per-CL state.
+const ACTIVE_ERRORS_KEY = 'active_errors';  // Active error conditions.
+
+// Return true if notifications are enabled.
+export async function notificationsEnabled() {
+  let options = browser.loadOptions();
+  let havePermissions = browser.haveNotificationPermissions();
+  return (await options).showNotifications === config.NOTIFICATIONS_ENABLED &&
+        (await havePermissions);
+}
+
+// Send notifications.
+export async function notify(results, errors) {
+  if (await notificationsEnabled()) {
+    await notifyErrors(errors);
+    await notifyCLs(results);
+  }
+};
+
+// Notify about any errors.
+//
+// We only notify about the first error per host until we see that host has had
+// a successful result again.
+async function notifyErrors(errorList) {
+  // Fetch known-bad hosts.
+  let badHosts = new Set(await browser.getLocalStorage(ACTIVE_ERRORS_KEY, new Array()));
+
+  // Show a notification for every host not already in the known-bad list.
+  let newBadHosts = new Array();
+  for (const error of errorList) {
+    if (!badHosts.has(error.host)) {
+      notifyError(error.host, "Could not load results from " + error.host + ": " + error.error);
+    }
+    newBadHosts.push(error.host);
+  }
+
+  // Update the new list.
+  browser.setLocalStorage(ACTIVE_ERRORS_KEY, newBadHosts);
+}
+
+// Send notifications about CLs on the given list.
+//
+// We only send a notification if the state of the CL has changed since we last
+// notified about it.
+async function notifyCLs(clList) {
+  // Load details about CLs we've already notified the user about.
+  let lastNotifications = new Map(await browser.getLocalStorage(CL_LAST_NOTIFICATION_KEY, new Array()));
+  let newNotificationState = new Map();
+
+  // Enumerate different categories of CLs.
+  var categories = clList.getCategoryMap();
+  for (const category of messages.SECTION_ORDERING) {
+    // If we don't have any CLs in this category, continue.
+    if (!categories.has(category)) {
+      continue;
+    }
+
+    // Get metadata about this category.
+    var category_data = messages.BADGE_DATA[category];
+    if (category_data === null) {
+      continue;
+    }
+
+    // If we don't need to notify about this category, continue.
+    if (!category_data.shouldNotify) {
+      continue;
+    }
+
+    // Iterate through CLs in this category.
+    for (const cl of categories.get(category)) {
+      newNotificationState.set(cl.getChangeId(), category);
+
+      // If we've already notified about this CL, skip it.
+      if (lastNotifications.get(cl.getChangeId()) === category) {
+        continue;
+      }
+
+      // Otherwise, send out a notification.
+      notifyCL(category_data, cl);
+    }
+  }
+
+  // Save notification state.
+  browser.setLocalStorage(CL_LAST_NOTIFICATION_KEY, Array.from(newNotificationState));
+}
+
+// Send an error notification.
+function notifyError(url, message) {
+  var options = {
+      type: "basic",
+      title: "Error fetching CL status",
+      iconUrl: 'img/ic_assignment_late_black_24dp_2x.png',
+      message: message,
+      requireInteraction: true,
+  };
+  browser.createNotification(url, options);
+};
+
+// Send a CL notification.
+function notifyCL(category, cl) {
+  var options = {
+    type: "basic",
+    title: category.notificationTitle,
+    iconUrl: category.icon['48'],
+    message: cl.getSubject(),
+    requireInteraction: true,
+  };
+  browser.createNotification(cl.getGerritUrl(), options);
+};

--- a/src/options.css
+++ b/src/options.css
@@ -16,11 +16,23 @@
 
 body {
   overflow-y: scroll;
-  margin: 0 10px 10px 10px;
+  width: 50rem;
+  margin: 1em auto 1em auto;
 }
 
+/* Table styling */
 table {
   width: 100%;
+}
+td, th {
+  padding: 3px 6px;
+}
+tr:nth-child(even) {
+  background: #F0F0F0;
+}
+thead {
+  font-weight: normal;
+  background: #D0D0D0;
 }
 
 div {
@@ -43,4 +55,9 @@ input:invalid {
 
 .center-aligned {
   text-align: center
+}
+
+.status-text {
+  font-weight: bold;
+  padding-right: 6px;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -22,6 +22,9 @@
     <link rel="stylesheet" href="options.css">
   </head>
   <body>
+    <h1>GerritMonitor</h1>
+
+    <h2>Gerrit Instances</h2>
 
     <table>
       <thead>
@@ -42,11 +45,7 @@
     </div>
 
     <div class="right-aligned">
-      <button id="save-button" style="">Save</button>
+      <span class="status-text" id="status"></span> <button id="save-button" style="">Save</button>
     </div>
-
-    <div id="status">
-    </div>
-
   </body>
 </html>

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,18 @@
       <button id="add-button">Add</button>
     </div>
 
+    <h2>Notification Settings (Experimental)</h2>
+    <div>
+      <label for="show-notifications">
+        Show notifications for CLs requiring attention:
+      </label>
+      <select id="show-notifications">
+        <option value="unspecified" default>Default (Disabled)</option>
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+    </div>
+
     <div class="right-aligned">
       <span class="status-text" id="status"></span> <button id="save-button" style="">Save</button>
     </div>


### PR DESCRIPTION
The two patches below implement basic notification support for GerritMonitor, currently defaulting to "off".

* The first patch tweaks the options page, making it a full-screen page instead of a window. This allows for additional options in the next patch.
* The second patch actually implements the notifications. We use local storage to do basic tracking of what notifications have been shown, only showing a CL again if it has changed state since the last notification.

More sophisticated features would be good, such as configuring what notifications are shown. The current implementation will also redisplay notifications after a failed server interaction, which isn't great. Despite the limitations, I've found it to be personally useful.

I don't have much experience in JavaScript, so any feedback is welcome.
