### PR TITLE
Add an option to disable error notifications

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -67,4 +67,6 @@ export const DEFAULT_OPTIONS = {
   showNotifications: OPTION_UNSPECIFIED,
   // And the same for relying solely on the Attention Set feature
   onlyAttentionSet: OPTION_UNSPECIFIED,
+  // Show notifications for errors
+  notifyForErrors: OPTION_UNSPECIFIED,
 };

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -31,10 +31,18 @@ export async function notificationsEnabled() {
          grantedPermissions.permissions.includes('notifications');
 }
 
+// Returns true if we should notify for errors.
+export async function notifyForErrors() {
+  const options = await browser.loadOptions();
+  return options.notifyForErrors != config.OPTION_DISABLED;
+}
+
 // Send notifications.
 export async function notify(results, errors) {
   if (await notificationsEnabled()) {
-    await notifyErrors(errors);
+    if (await notifyForErrors()) {
+      await notifyErrors(errors);
+    }
     await notifyCLs(results);
   }
 };

--- a/src/options.html
+++ b/src/options.html
@@ -66,7 +66,16 @@
         <option value="disabled">Disabled</option>
       </select>
     </div>
-
+    <div>
+      <label for="notify-for-errors">
+        Show notifications for errors:
+      </label>
+      <select id="notify-for-errors">
+        <option value="unspecified" default>Default (Enabled)</option>
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+    </div>
     <div class="right-aligned">
       <span class="status-text" id="status"></span> <button id="save-button" style="">Save</button>
     </div>

--- a/src/options.js
+++ b/src/options.js
@@ -23,6 +23,7 @@ export class Options {
     this.instances_ = [];
     this.onlyAttentionSet_ = config.OPTION_UNSPECIFIED;
     this.showNotifications_ = config.OPTION_UNSPECIFIED;
+    this.notifyForErrors_ = config.OPTION_UNSPECIFIED;
   }
 
   // Return the value for option.
@@ -33,6 +34,11 @@ export class Options {
   // Return true if notifications are enabled.
   notificationsEnabled() {
     return this.showNotifications_ !== config.OPTION_DISABLED;
+  }
+
+  // Return true if we should notify on error.
+  notifyOnErrorsEnabled() {
+    return this.notifyForErrors_ !== config.OPTION_DISABLED;
   }
 
   // Sets the status text (with a timeout).
@@ -150,6 +156,14 @@ export class Options {
     } else {
       this.showNotifications_ = config.OPTION_UNSPECIFIED;
     }
+
+    // Update the notify on error option.
+    if (options.notifyForErrors !== undefined) {
+      this.notifyForErrors_ = options.notifyForErrors;
+      browser.getElement('notify-for-errors').value = options.notifyForErrors;
+    } else {
+      this.notifyForErrors_ = config.OPTION_UNSPECIFIED;
+    }
   }
 
   // Save the options to Chrome storage and update permissions.
@@ -168,6 +182,7 @@ export class Options {
       instances: instances,
       onlyAttentionSet: this.onlyAttentionSet_,
       showNotifications: this.showNotifications_,
+      notifyForErrors: this.notifyForErrors_,
     };
 
     // Determine the set of origins we need access to.
@@ -231,6 +246,11 @@ export class Options {
     // Set up "show-notifications" option.
     browser.getElement('show-notifications').addEventListener('change', (function () {
       this.showNotifications_ = browser.getElement('show-notifications').value;
+    }).bind(this));
+
+    // Set up "show-notifications" option.
+    browser.getElement('notify-for-errors').addEventListener('change', (function () {
+      this.notifyForErrors_ = browser.getElement('notify-for-errors').value;
     }).bind(this));
 
     browser.getElement('save-button').addEventListener('click', (function () {


### PR DESCRIPTION
I see an error every morning as my SSO token expires over night. This change allows the user to disable the error notifications so they do not see the error notification.