### PR TITLE
Ignore abandoned and merged changes for attentionset

### DIFF
--- a/src/gerrit.js
+++ b/src/gerrit.js
@@ -632,7 +632,7 @@ export function fetchAccount(host) {
 export function fetchReviews(host, account) {
   var params = [];
   var userid = account._account_id;
-  params.push(['q', 'attention:' + userid]);
+  params.push(['q', 'status:open attention:' + userid]);
   params.push(['q', 'status:open owner:' + userid + ' -attention:' + userid]);
   params.push(['q', 'status:open -star:ignore reviewer:' + userid +
       ' -owner:' + userid + ' -attention:' + userid]);


### PR DESCRIPTION
Attention set based notifications would still come in for abandoned and
merged changes due to the status portion of the query being left out.

This is annoying as I was often in the attentionset for changes abandoned
and it was difficult to figure out why gerrit-monitor continued to think I
should be notified for these for the past few months.