### PR TITLE
properly escape regex err on options page

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -222,7 +222,7 @@ export class Options {
     this.loadOptions();
 
     browser.getElement('add-button-name').pattern = '.+';
-    browser.getElement('add-button-host').pattern = config.ORIGIN_PATTERN;
+    browser.getElement('add-button-host').pattern = config.ORIGIN_PATTERN.replace(/\//g, '\\/');
     browser.getElement('add-button').addEventListener('click', (function () {
       var host = browser.getElement('add-button-host').value;
       var name = browser.getElement('add-button-name').value;


### PR DESCRIPTION
not _the_ bug, but one that came up in #49.

`pattern` takes a regex, and `ORIGIN_PATTERN` has multiple unescaped `/`, so it is throwing 
```
Pattern attribute value (https?://[^/]*)(/[^/]+)* is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /(https?://[^/]*)(/[^/]+)*/v: Invalid character in character class
```