### PR TITLE
Fix popup when a CL doesn't have revisions

### DIFF
--- a/src/gerrit.js
+++ b/src/gerrit.js
@@ -334,13 +334,17 @@ export class Changelist {
     return this.json_.subject;
   }
 
-  // Returns the CL description.
+  // Returns the CL description or null if not available.
   //
   // Requires detailed information (see fetchReviews).
   getDescription() {
     if (this.description_ === null) {
-      this.description_ = new Description(
-          this.getCurrentRevision().toJSON().commit.message);
+      const currentRevision = this.getCurrentRevision().toJSON();
+      if (currentRevision !== undefined) {
+        this.description_ = new Description(currentRevision.commit.message);
+      } else {
+        this.description_ = null;
+      }
     }
     return this.description_;
   }

--- a/src/popup.js
+++ b/src/popup.js
@@ -162,7 +162,7 @@ class ChangelistWidget {
 
   // Returns the CL description.
   getDescription() {
-    return this.cl_.getDescription();
+    return this.cl_.getDescription()?.getMessage?.() ?? this.cl_.getSubject();
   }
 
   // Configure click event on the table row.
@@ -218,7 +218,7 @@ class ChangelistWidget {
               .begin('td')
                 .begin('div')
                   .addClass('description')
-                  .appendText(this.getDescription().getMessage())
+                  .appendText(this.getDescription())
                 .end('div')
               .end('td')
             .end('tr')


### PR DESCRIPTION
When a CL doesn't have revisions, the current revision can't be found and thus we can't retrieve the current revision's description.

This CL fixes this by returning null in getDescription() when this happens, and falling back to the change's subject in the CL widget.

Fixes #52